### PR TITLE
Check equality of source and destination files

### DIFF
--- a/import_photo.py
+++ b/import_photo.py
@@ -6,8 +6,9 @@ import glob
 import json
 import os
 import shutil
-
 import exifread
+
+from utils import files
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Import photos (*.jpg; *.jpeg) into specified folder organizing them according to EXIF DateTimeOriginal tag")
@@ -51,7 +52,8 @@ if __name__ == '__main__':
 
                     dst_file = os.path.join(dst_dir, os.path.basename(src_file))
                     if os.path.exists(dst_file):
-                        print('[WARNING] File already exists {0}'.format(dst_file))
+                        if not files.equal(src_file, dst_file):
+                            print('[WARNING] Different file already exists {0}'.format(dst_file))
                         continue
 
                     shutil.copy(src_file, dst_dir)

--- a/import_video.py
+++ b/import_video.py
@@ -10,6 +10,8 @@ import time
 
 from datetime import datetime
 
+from utils import files
+
 
 def copy_file(video_file, out_dir):
     """ Copy video file into %Y-%m-%d subfolder of the out_dir """
@@ -31,12 +33,13 @@ def copy_file(video_file, out_dir):
             dt = datetime.strptime(tags['creation_time'], '%Y-%m-%dT%H:%M:%S.%fZ') + utc_offset
 
             dst_dir = os.path.join(out_dir, dt.strftime('%Y-%m-%d'))
+            os.makedirs(dst_dir, exist_ok=True)
 
             dst_file = os.path.join(dst_dir, os.path.basename(video_file))
             if os.path.exists(dst_file):
-                print('[WARNING] File already exists {0}'.format(dst_file))
+                if not files.equal(video_file, dst_file):
+                    print('[WARNING] Different file already exists {0}'.format(dst_file))
             else:
-                os.makedirs(dst_dir, exist_ok=True)
                 shutil.copy(video_file, dst_dir)
 
                 imported.append(os.sep.join(

--- a/utils/files.py
+++ b/utils/files.py
@@ -1,0 +1,21 @@
+import hashlib
+
+
+def hash(file) -> str:
+    """Returns SHA256 of first 2MB of file contents"""
+
+    BUF_SIZE = 2000000
+    with open(file, 'rb') as f:
+        data = f.read(BUF_SIZE)
+        if data:
+            sha256 = hashlib.sha256()
+            sha256.update(data)
+
+            return sha256.hexdigest()
+
+    return ""
+
+
+def equal(fst, snd) -> bool:
+    """Returns if files are equal by calculating their hash"""
+    return hash(fst) == hash(snd)


### PR DESCRIPTION
If destination directory already contains the file with the same name than compare SHA256 hash of both files. Do not report warning if files are equal. Hash is only calculated for the first 2MB of file contents.